### PR TITLE
Fix exit logic in Install.ps1

### DIFF
--- a/dev-workstation/Install.ps1
+++ b/dev-workstation/Install.ps1
@@ -5,7 +5,7 @@ write-host "Powershell version: " $PSVersionTable.PSVersion
 If (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {   
     $arguments = "& '" + $myinvocation.mycommand.definition + "'"
     Start-Process powershell -Verb runAs -ArgumentList $arguments
-    Break
+    exit
 }
 
 # allow our own powershell scripts


### PR DESCRIPTION
## Summary
- fix exit from Install.ps1 when elevation is requested

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686240bc22488320aa20847ea162c2c4